### PR TITLE
fix(docs): accessibility, CDN robustness, data accuracy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>~/.claude ディレクトリ構造</title>
-<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.3/dist/mermaid.min.js"
+        integrity="sha384-R63zfMfSwJF4xCR11wXii+QUsbiBIdiDzDbtxia72oGWfkT7WHJfmD/I/eeHPJyT"
+        crossorigin="anonymous"
+        onerror="window.__mermaidFailed=true"></script>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
@@ -126,11 +129,11 @@
     <div class="ztb" id="ztb-overview">
       <span class="ztb-pct" id="pct-overview">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('overview','zoomBy',1.35)" title="ズームイン">＋</button>
-      <button onclick="zpCall('overview','zoomBy',0.74)" title="ズームアウト">－</button>
+      <button onclick="zpCall('overview','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('overview','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('overview','fit')" title="画面にフィット">⊡</button>
-      <button onclick="zpCall('overview','reset')" title="リセット">↺</button>
+      <button onclick="zpCall('overview','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
+      <button onclick="zpCall('overview','reset')" title="リセット" aria-label="リセット">↺</button>
     </div>
     <div class="diagram-canvas" id="dc-overview">
       <div class="mermaid">
@@ -151,7 +154,7 @@ graph TD
 
     EXT --> COMMANDS["📁 commands/<br/><small>スラッシュコマンド 30+</small>"]:::commands
     EXT --> SKILLS["📁 skills/<br/><small>89 スキル</small>"]:::skills
-    EXT --> AGENTS["📁 agents/<br/><small>サブエージェント定義 13</small>"]:::agents
+    EXT --> AGENTS["📁 agents/<br/><small>サブエージェント定義 10</small>"]:::agents
     EXT --> PLUGINS["📁 plugins/<br/><small>claude-code-harness 等</small>"]:::plugins
 
     STORAGE --> DATA["📁 projects/ + session-search/<br/><small>履歴・ChromaDB・永続メモリ</small>"]:::data
@@ -195,7 +198,7 @@ graph TD
     <div class="legend-item"><div class="dot" style="background:#2ea043"></div>Hooks (自動実行)</div>
     <div class="legend-item"><div class="dot" style="background:#1f6feb"></div>Commands (スラッシュ)</div>
     <div class="legend-item"><div class="dot" style="background:#0ea5e9"></div>Skills (89個)</div>
-    <div class="legend-item"><div class="dot" style="background:#d97706"></div>Agents (13個)</div>
+    <div class="legend-item"><div class="dot" style="background:#d97706"></div>Agents (10個)</div>
     <div class="legend-item"><div class="dot" style="background:#ec4899"></div>Rules (詳細ルール)</div>
     <div class="legend-item"><div class="dot" style="background:#7c3aed"></div>Config (設定ファイル)</div>
   </div>
@@ -207,11 +210,11 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-hooks">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('hooks','zoomBy',1.35)">＋</button>
-      <button onclick="zpCall('hooks','zoomBy',0.74)">－</button>
+      <button onclick="zpCall('hooks','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('hooks','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('hooks','fit')" title="画面にフィット">⊡</button>
-      <button onclick="zpCall('hooks','reset')">↺</button>
+      <button onclick="zpCall('hooks','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
+      <button onclick="zpCall('hooks','reset')" title="リセット" aria-label="リセット">↺</button>
     </div>
     <div class="diagram-canvas" id="dc-hooks">
       <div class="mermaid">
@@ -270,11 +273,11 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-commands">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('commands','zoomBy',1.35)">＋</button>
-      <button onclick="zpCall('commands','zoomBy',0.74)">－</button>
+      <button onclick="zpCall('commands','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('commands','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('commands','fit')">⊡</button>
-      <button onclick="zpCall('commands','reset')">↺</button>
+      <button onclick="zpCall('commands','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
+      <button onclick="zpCall('commands','reset')" title="リセット" aria-label="リセット">↺</button>
     </div>
     <div class="diagram-canvas" id="dc-commands">
       <div class="mermaid">
@@ -343,11 +346,11 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-rules">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('rules','zoomBy',1.35)">＋</button>
-      <button onclick="zpCall('rules','zoomBy',0.74)">－</button>
+      <button onclick="zpCall('rules','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('rules','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('rules','fit')">⊡</button>
-      <button onclick="zpCall('rules','reset')">↺</button>
+      <button onclick="zpCall('rules','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
+      <button onclick="zpCall('rules','reset')" title="リセット" aria-label="リセット">↺</button>
     </div>
     <div class="diagram-canvas" id="dc-rules">
       <div class="mermaid">
@@ -389,11 +392,11 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-skills">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('skills','zoomBy',1.35)">＋</button>
-      <button onclick="zpCall('skills','zoomBy',0.74)">－</button>
+      <button onclick="zpCall('skills','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('skills','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('skills','fit')">⊡</button>
-      <button onclick="zpCall('skills','reset')">↺</button>
+      <button onclick="zpCall('skills','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
+      <button onclick="zpCall('skills','reset')" title="リセット" aria-label="リセット">↺</button>
     </div>
     <div class="diagram-canvas" id="dc-skills">
       <div class="mermaid">
@@ -432,37 +435,37 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-channels">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('channels','zoomBy',1.35)">＋</button>
-      <button onclick="zpCall('channels','zoomBy',0.74)">－</button>
+      <button onclick="zpCall('channels','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('channels','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('channels','fit')">⊡</button>
-      <button onclick="zpCall('channels','reset')">↺</button>
+      <button onclick="zpCall('channels','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
+      <button onclick="zpCall('channels','reset')" title="リセット" aria-label="リセット">↺</button>
     </div>
     <div class="diagram-canvas" id="dc-channels">
       <div class="mermaid">
 graph TD
     subgraph CHANNELS["📁 channels/ — 通信チャンネル"]
-      DISCORD["📁 discord/<br/><small>Discord Bot連携<br/>MCP経由でメッセージ送受信</small>"]
-      SB["📁 script-bridge/<br/><small>ローカルスクリプトからの<br/>リクエスト受付</small>"]
-      SBL["📁 script-bridge-lower/<br/>📁 script-bridge-upper/<br/><small>優先度別キュー</small>"]
+      DISCORD["📁 discord/<br/><small>Discord Bot連携<br/>MCP経由でメッセージ送受信</small>"]:::ch
+      SB["📁 script-bridge/<br/><small>ローカルスクリプトからの<br/>リクエスト受付</small>"]:::ch
+      SBL["📁 script-bridge-lower/<br/>📁 script-bridge-upper/<br/><small>優先度別キュー</small>"]:::ch
     end
 
-    subgraph AGENTS["📁 agents/ — サブエージェント定義 (13)"]
-      CODE_R["code-reviewer.md<br/><small>コードレビュー専門</small>"]
-      CODE_S["code-simplifier.md<br/><small>コード簡略化</small>"]
-      DEP["deployment-specialist.md<br/><small>Cloud Runデプロイ</small>"]
-      GH["github-integration-specialist.md<br/><small>GitHub Issue/PR管理</small>"]
-      UI_V["ui-verification-specialist.md<br/><small>UI視覚検証 + スクショ確認</small>"]
-      SCREEN["screen-verification-specialist.md<br/><small>画面確認 + CiC操作</small>"]
-      UX["ux-researcher.md<br/><small>UXリサーチ</small>"]
-      UI_D["ui-designer.md<br/><small>UIデザイン生成</small>"]
-      PR_T["pr-test-analyzer.md<br/><small>PRテスト分析</small>"]
-      SF["silent-failure-hunter.md<br/><small>サイレント失敗検出</small>"]
+    subgraph AGENTS["📁 agents/ — サブエージェント定義 (10)"]
+      CODE_R["code-reviewer.md<br/><small>コードレビュー専門</small>"]:::ag
+      CODE_S["code-simplifier.md<br/><small>コード簡略化</small>"]:::ag
+      DEP["deployment-specialist.md<br/><small>Cloud Runデプロイ</small>"]:::ag
+      GH["github-integration-specialist.md<br/><small>GitHub Issue/PR管理</small>"]:::ag
+      UI_V["ui-verification-specialist.md<br/><small>UI視覚検証 + スクショ確認</small>"]:::ag
+      SCREEN["screen-verification-specialist.md<br/><small>画面確認 + CiC操作</small>"]:::ag
+      UX["ux-researcher.md<br/><small>UXリサーチ</small>"]:::ag
+      UI_D["ui-designer.md<br/><small>UIデザイン生成</small>"]:::ag
+      PR_T["pr-test-analyzer.md<br/><small>PRテスト分析</small>"]:::ag
+      SF["silent-failure-hunter.md<br/><small>サイレント失敗検出</small>"]:::ag
     end
 
     subgraph PLUGINS["📁 plugins/ — プラグイン"]
-      HARNESS["claude-code-harness/<br/><small>ハーネス本体<br/>review-loopスキル含む</small>"]
-      PR_TK["pr-review-toolkit/<br/><small>PR並列レビューツール</small>"]
+      HARNESS["claude-code-harness/<br/><small>ハーネス本体<br/>review-loopスキル含む</small>"]:::pl
+      PR_TK["pr-review-toolkit/<br/><small>PR並列レビューツール</small>"]:::pl
     end
 
     classDef ch fill:#3a0d3a,stroke:#a855f7,color:#d8b4fe
@@ -475,6 +478,11 @@ graph TD
 </div>
 
 <script>
+if (window.__mermaidFailed || typeof mermaid === 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.innerHTML = '<p style="color:#f85149;padding:2rem;font-family:sans-serif">Mermaid CDN の読み込みに失敗しました。ネットワーク接続を確認してリロードしてください。</p>';
+  });
+} else {
 mermaid.initialize({
   startOnLoad: true,
   theme: 'dark',
@@ -500,6 +508,7 @@ mermaid.initialize({
     padding: 10
   }
 });
+} // end mermaid guard
 
 // ── ZoomPan ──────────────────────────────────────────
 class ZoomPan {
@@ -597,22 +606,30 @@ function zpCall(id, method, arg) {
   if (zp[id]) zp[id][method](arg);
 }
 
-// Init after Mermaid finishes rendering
-window.addEventListener('load', () => {
-  setTimeout(() => {
-    PANELS.forEach(id => { zp[id] = new ZoomPan(id); });
-    // Auto-fit overview
-    setTimeout(() => { if (zp['overview']) zp['overview'].fit(); }, 80);
-  }, 600);
-});
+// Init after Mermaid finishes rendering (SVG existence check with retry)
+function initAllPanels() {
+  if (window.__mermaidFailed || typeof mermaid === 'undefined') return;
+  const svg = document.querySelector('.mermaid svg');
+  if (!svg) {
+    // Mermaid未レンダリング: 200msごとにリトライ（最大15回 = 3秒）
+    if (!initAllPanels._retries) initAllPanels._retries = 0;
+    if (++initAllPanels._retries <= 15) {
+      setTimeout(initAllPanels, 200);
+      return;
+    }
+  }
+  PANELS.forEach(id => { if (!zp[id]) zp[id] = new ZoomPan(id); });
+  if (zp['overview']) zp['overview'].fit();
+}
+window.addEventListener('load', initAllPanels);
 
-// Tab switching
+// Tab switching (re-fit on panel change)
 function showPanel(name, btn) {
   document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
   document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
   document.getElementById('panel-' + name).classList.add('active');
   btn.classList.add('active');
-  // Lazy init + auto-fit when switching tabs
+  // Re-fit after panel becomes visible (display:flex triggers reflow)
   setTimeout(() => {
     if (!zp[name]) zp[name] = new ZoomPan(name);
     zp[name].fit();

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,8 +129,8 @@
     <div class="ztb" id="ztb-overview">
       <span class="ztb-pct" id="pct-overview">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('overview','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
-      <button onclick="zpCall('overview','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
+      <button onclick="zpCall('overview','zoomBy',CFG.zoomIn)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('overview','zoomBy',CFG.zoomOut)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
       <button onclick="zpCall('overview','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
       <button onclick="zpCall('overview','reset')" title="リセット" aria-label="リセット">↺</button>
@@ -210,8 +210,8 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-hooks">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('hooks','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
-      <button onclick="zpCall('hooks','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
+      <button onclick="zpCall('hooks','zoomBy',CFG.zoomIn)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('hooks','zoomBy',CFG.zoomOut)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
       <button onclick="zpCall('hooks','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
       <button onclick="zpCall('hooks','reset')" title="リセット" aria-label="リセット">↺</button>
@@ -273,8 +273,8 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-commands">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('commands','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
-      <button onclick="zpCall('commands','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
+      <button onclick="zpCall('commands','zoomBy',CFG.zoomIn)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('commands','zoomBy',CFG.zoomOut)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
       <button onclick="zpCall('commands','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
       <button onclick="zpCall('commands','reset')" title="リセット" aria-label="リセット">↺</button>
@@ -346,8 +346,8 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-rules">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('rules','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
-      <button onclick="zpCall('rules','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
+      <button onclick="zpCall('rules','zoomBy',CFG.zoomIn)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('rules','zoomBy',CFG.zoomOut)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
       <button onclick="zpCall('rules','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
       <button onclick="zpCall('rules','reset')" title="リセット" aria-label="リセット">↺</button>
@@ -392,8 +392,8 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-skills">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('skills','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
-      <button onclick="zpCall('skills','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
+      <button onclick="zpCall('skills','zoomBy',CFG.zoomIn)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('skills','zoomBy',CFG.zoomOut)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
       <button onclick="zpCall('skills','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
       <button onclick="zpCall('skills','reset')" title="リセット" aria-label="リセット">↺</button>
@@ -435,8 +435,8 @@ graph TD
     <div class="ztb">
       <span class="ztb-pct" id="pct-channels">100%</span>
       <div class="ztb-sep"></div>
-      <button onclick="zpCall('channels','zoomBy',1.35)" title="ズームイン" aria-label="ズームイン">＋</button>
-      <button onclick="zpCall('channels','zoomBy',0.74)" title="ズームアウト" aria-label="ズームアウト">－</button>
+      <button onclick="zpCall('channels','zoomBy',CFG.zoomIn)" title="ズームイン" aria-label="ズームイン">＋</button>
+      <button onclick="zpCall('channels','zoomBy',CFG.zoomOut)" title="ズームアウト" aria-label="ズームアウト">－</button>
       <div class="ztb-sep"></div>
       <button onclick="zpCall('channels','fit')" title="画面にフィット" aria-label="画面にフィット">⊡</button>
       <button onclick="zpCall('channels','reset')" title="リセット" aria-label="リセット">↺</button>
@@ -510,6 +510,22 @@ mermaid.initialize({
 });
 } // end mermaid guard
 
+// ── Config ───────────────────────────────────────────
+const CFG = {
+  zoomIn:       1.35,  // ボタンクリック時のズームイン倍率
+  zoomOut:      0.74,  // ボタンクリック時のズームアウト倍率
+  wheelIn:      1.20,  // マウスホイールズームイン倍率
+  wheelOut:     0.83,  // マウスホイールズームアウト倍率
+  scaleMin:     0.05,  // 最小ズーム倍率
+  scaleMax:     20,    // 最大ズーム倍率
+  fitMax:       1.5,   // fit時の最大倍率（等倍以上に拡大しすぎない）
+  fitPad:       8,     // fit時のビューポート余白(px)
+  fitOffset:    4,     // fit時の位置オフセット(px)
+  initRetryMs:  200,   // Mermaid描画待ちリトライ間隔(ms)
+  initMaxRetry: 15,    // Mermaid描画待ち最大リトライ回数
+  tabSwitchMs:  120,   // タブ切り替え後のfit遅延(ms)
+};
+
 // ── ZoomPan ──────────────────────────────────────────
 class ZoomPan {
   constructor(id) {
@@ -530,7 +546,7 @@ class ZoomPan {
   }
 
   zoomAt(f, px, py) {
-    const ns = Math.max(0.05, Math.min(20, this.s * f));
+    const ns = Math.max(CFG.scaleMin, Math.min(CFG.scaleMax, this.s * f));
     const r  = this.vp.getBoundingClientRect();
     const cx = (px != null ? px : r.left + r.width  / 2) - r.left;
     const cy = (py != null ? py : r.top  + r.height / 2) - r.top;
@@ -548,15 +564,15 @@ class ZoomPan {
     requestAnimationFrame(() => {
       const svg = this.dc.querySelector('svg');
       if (!svg) return;
-      const vw = this.vp.clientWidth  - 8;
-      const vh = this.vp.clientHeight - 8;
+      const vw = this.vp.clientWidth  - CFG.fitPad;
+      const vh = this.vp.clientHeight - CFG.fitPad;
       const sw = svg.scrollWidth  || svg.getBBox().width;
       const sh = svg.scrollHeight || svg.getBBox().height;
       if (!sw || !sh) return;
-      const ns = Math.min(vw / sw, vh / sh, 1.5);
+      const ns = Math.min(vw / sw, vh / sh, CFG.fitMax);
       this.s = ns;
-      this.x = (vw - sw * ns) / 2 + 4;
-      this.y = Math.max(4, (vh - sh * ns) / 2 + 4);
+      this.x = (vw - sw * ns) / 2 + CFG.fitOffset;
+      this.y = Math.max(CFG.fitOffset, (vh - sh * ns) / 2 + CFG.fitOffset);
       this._apply();
     });
   }
@@ -567,7 +583,7 @@ class ZoomPan {
     // Mouse wheel zoom
     this.vp.addEventListener('wheel', e => {
       e.preventDefault();
-      this.zoomAt(e.deltaY < 0 ? 1.20 : 0.83, e.clientX, e.clientY);
+      this.zoomAt(e.deltaY < 0 ? CFG.wheelIn : CFG.wheelOut, e.clientX, e.clientY);
     }, { passive: false });
 
     // Drag to pan (ignore clicks on toolbar)
@@ -613,8 +629,8 @@ function initAllPanels() {
   if (!svg) {
     // Mermaid未レンダリング: 200msごとにリトライ（最大15回 = 3秒）
     if (!initAllPanels._retries) initAllPanels._retries = 0;
-    if (++initAllPanels._retries <= 15) {
-      setTimeout(initAllPanels, 200);
+    if (++initAllPanels._retries <= CFG.initMaxRetry) {
+      setTimeout(initAllPanels, CFG.initRetryMs);
       return;
     }
   }
@@ -633,7 +649,7 @@ function showPanel(name, btn) {
   setTimeout(() => {
     if (!zp[name]) zp[name] = new ZoomPan(name);
     zp[name].fit();
-  }, 120);
+  }, CFG.tabSwitchMs);
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Mermaid CDN v10.9.3固定 + SRI integrity hash追加
- CDN読み込み失敗時の安全なフォールバック表示
- 全6パネルのズームボタンにaria-label/title追加
- channelsパネルのclassDefをノードに適用
- サブエージェント数13→10に全箇所統一
- initAllPanelsのidempotent化（二重バインド防止）

## Test plan
- [ ] GitHub Pages URLでページが正常表示されること
- [ ] 各パネルのズーム・パン操作が動作すること
- [ ] CDN障害シミュレーション時にフォールバック表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)