### PR TITLE
chore: public-readiness — LICENSE, CI, badges for pin-ready status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run tests
+        run: pytest tests/ -xvs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .letta/
+.claude/
 __pycache__/
 *.pyc
 *.pyo
 *.bak
+.pytest_cache/
+.playwright-cli/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tenormusica2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # claude-code-hooks
 
+[![test](https://github.com/Tenormusica2024/claude-code-hooks/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/Tenormusica2024/claude-code-hooks/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
+
 Claude Code の品質ガードレール用 Stop hooks。
 ユーザーへの確認委譲を検出してblockし、Claude自身に自己修正させる。
 


### PR DESCRIPTION
## Summary
ピン止め可能な公開リポジトリの体裁を整える整備コミット。秘密情報・追跡ファイルの混入は元からゼロで、欠けていたのは以下のメタ/運用ファイルのみ。

- **LICENSE (MIT)** 追加 — 公開repoの事実上の必須要件
- **GitHub Actions CI** 追加 — `.github/workflows/test.yml` で Python 3.10/3.11/3.12 × pytest
- **README バッジ** 追加（CI status / License / Python version）
- **.gitignore 拡張** — `.claude/`, `.pytest_cache/`, `.playwright-cli/`
- **GitHub repo メタデータ** — description/topics を設定済み（別コマンドで適用済、本PR外）

## Score Delta (Public Readiness profile)
- Before: **61/100 (Needs Work)**
- After: **93/100 (Ready)** 見込み
- 減点残: CODEOWNERS 不在 -7（個人repoのため優先度低）

## Test plan
- [ ] CI（test.yml）が Actions タブで green になることを確認
- [ ] README バッジが通ることを確認
- [ ] ピン止めカード上で description/topics が表示されることを確認（repo > About > Pin to profile）

🤖 Generated with [Claude Code](https://claude.com/claude-code)